### PR TITLE
Updated song search API to behave more like Song Library when multiple words are provided in the term.

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -103,12 +103,26 @@ class ApiController extends AbstractController
     #[Route(path: '/api/search/{term}', name: 'api_search')]
     public function index(Request $request, string $term = null, SongRepository $songRepository): Response
     {
-        $songsEntities = $songRepository
-            ->createQueryBuilder('s')->where('(s.name LIKE :search_string OR s.authorName LIKE :search_string OR s.levelAuthorName LIKE :search_string)')
-            ->andWhere('(s.programmationDate <= :now  )')
+        $qb = $songRepository
+            ->createQueryBuilder('s')->where('(s.programmationDate <= :now  )')
             ->setParameter('now', (new \DateTime()))
             ->andWhere('s.moderated = true')
-            ->andWhere('s.isDeleted != true')->setParameter('search_string', '%' . $term . '%')->getQuery()->getResult();
+            ->andWhere('s.isDeleted != true');
+
+        $searchString = explode(' ', trim($term));
+        foreach ($searchString as $key => $search) {
+            $qb
+                ->andWhere(
+                    $qb->expr()->orX(
+                        's.name LIKE :search_string' . $key,
+                        's.authorName LIKE :search_string' . $key,
+                        's.levelAuthorName LIKE :search_string' . $key
+                    )
+                )
+                ->setParameter('search_string' . $key, '%' . $search . '%');
+        }
+
+        $songsEntities = $qb->getQuery()->getResult();
         $songs = [];
 
         /** @var Song $song */

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -40,7 +40,7 @@ class ApiController extends AbstractController
     #[Route(path: '/api/check', name: 'check_api_key')]
     public function checkApiKey(Request $request, UtilisateurRepository $utilisateurRepository): Response
     {
-        $apiKey = $request->headers->get('x-api-key', 'none');
+        $apiKey = $request->headers->get('x-api-key','none');
 
         $user = $utilisateurRepository->findOneBy(['apiKey' => $apiKey]);
         if ($user) {
@@ -65,7 +65,7 @@ class ApiController extends AbstractController
                 return new Response($user->getApiKey());
             }
 
-            $user->setCountApiAttempt((int) $user->getCountApiAttempt() + 1);
+            $user->setCountApiAttempt((int)$user->getCountApiAttempt() + 1);
             $user->setLastApiAttempt(new DateTime());
             $utilisateurRepository->add($user);
 
@@ -89,12 +89,12 @@ class ApiController extends AbstractController
          * "Difficulties" => $song->getSongDifficultiesStr(),
          */
         $songs = $songRepository->createQueryBuilder('s')
-            ->select('s.id, s.name, s.authorName AS author, s.levelAuthorName AS mapper, s.newGuid AS hash, GROUP_CONCAT(r.level) AS Difficulties')
-            ->leftJoin("s.songDifficulties", 'sd')
-            ->leftJoin('sd.difficultyRank', 'r')
-            ->where("s.isDeleted != 1")
-            ->groupBy('s.id')
-            ->getQuery()->getArrayResult();
+                                ->select('s.id, s.name, s.authorName AS author, s.levelAuthorName AS mapper, s.newGuid AS hash, GROUP_CONCAT(r.level) AS Difficulties')
+                                ->leftJoin("s.songDifficulties", 'sd')
+                                ->leftJoin('sd.difficultyRank', 'r')
+                                ->where("s.isDeleted != 1")
+                                ->groupBy('s.id')
+                                ->getQuery()->getArrayResult();
 
         return new JsonResponse($songs);
     }
@@ -103,26 +103,12 @@ class ApiController extends AbstractController
     #[Route(path: '/api/search/{term}', name: 'api_search')]
     public function index(Request $request, string $term = null, SongRepository $songRepository): Response
     {
-        $qb = $songRepository
-            ->createQueryBuilder('s')->where('(s.programmationDate <= :now  )')
+        $songsEntities = $songRepository
+            ->createQueryBuilder('s')->where('(s.name LIKE :search_string OR s.authorName LIKE :search_string OR s.levelAuthorName LIKE :search_string)')
+            ->andWhere('(s.programmationDate <= :now  )')
             ->setParameter('now', (new \DateTime()))
             ->andWhere('s.moderated = true')
-            ->andWhere('s.isDeleted != true');
-
-        $searchString = explode(' ', trim($term));
-        foreach ($searchString as $key => $search) {
-            $qb
-                ->andWhere(
-                    $qb->expr()->orX(
-                        's.name LIKE :search_string' . $key,
-                        's.authorName LIKE :search_string' . $key,
-                        's.levelAuthorName LIKE :search_string' . $key
-                    )
-                )
-                ->setParameter('search_string' . $key, '%' . $search . '%');
-        }
-
-        $songsEntities = $qb->getQuery()->getResult();
+            ->andWhere('s.isDeleted != true')->setParameter('search_string', '%' . $term . '%')->getQuery()->getResult();
         $songs = [];
 
         /** @var Song $song */
@@ -132,7 +118,7 @@ class ApiController extends AbstractController
 
         return new JsonResponse([
             "Results" => $songs,
-            "Count" => count($songs)
+            "Count"   => count($songs)
         ]);
     }
 
@@ -173,14 +159,14 @@ class ApiController extends AbstractController
     {
         /** @var ScoreHistory[] $scores */
         $scores = $scoreRepository->createQueryBuilder("score")
-            ->leftJoin("score.songDifficulty", 'diff')
-            ->leftJoin("diff.song", 's')
-            ->orderBy('score.updatedAt', 'DESC')
-            ->where('s.isDeleted != true')
-            ->andWhere('s.wip != true')
-            ->setFirstResult(0)
-            ->setMaxResults($results)
-            ->getQuery()->getResult();
+                                  ->leftJoin("score.songDifficulty", 'diff')
+                                  ->leftJoin("diff.song", 's')
+                                  ->orderBy('score.updatedAt', 'DESC')
+                                  ->where('s.isDeleted != true')
+                                  ->andWhere('s.wip != true')
+                                  ->setFirstResult(0)
+                                  ->setMaxResults($results)
+                                  ->getQuery()->getResult();
         /** @var Song[] $songs */
         $songs = array_map(function (ScoreHistory $score) {
             return $score->getSongDifficulty()->getSong();
@@ -202,12 +188,12 @@ class ApiController extends AbstractController
     {
         /** @var Song[] $songs */
         $songs = $songRepository->createQueryBuilder("s")
-            ->orderBy("s.createdAt", 'DESC')
-            ->where('s.isDeleted != true')
-            ->andWhere('s.wip != true')
-            ->setMaxResults($results)
-            ->setFirstResult(0)
-            ->getQuery()->getResult();
+                                ->orderBy("s.createdAt", 'DESC')
+                                ->where('s.isDeleted != true')
+                                ->andWhere('s.wip != true')
+                                ->setMaxResults($results)
+                                ->setFirstResult(0)
+                                ->getQuery()->getResult();
         $data = [];
         foreach ($songs as $song) {
             $data[] = $song->__api();
@@ -226,17 +212,17 @@ class ApiController extends AbstractController
     {
         /** @var Song[] $songs */
         $songs = $songRepository->createQueryBuilder("s")
-            ->addSelect('s, SUM(IF(v.votes_indc IS NULL,0,IF(v.votes_indc = 0,-1,1))) AS HIDDEN sum_votes')
-            ->leftJoin("s.voteCounters", 'v')
-            ->orderBy("sum_votes", 'DESC')
-            ->where('s.isDeleted != true')
-            ->andWhere('s.wip != true')
-            ->andWhere('v.updatedAt >= :date')
-            ->setParameter('date', (new \DateTime())->modify('-' . $days . " days"))
-            ->groupBy('s.id')
-            ->setMaxResults($results)
-            ->setFirstResult(0)
-            ->getQuery()->getResult();
+                                ->addSelect('s, SUM(IF(v.votes_indc IS NULL,0,IF(v.votes_indc = 0,-1,1))) AS HIDDEN sum_votes')
+                                ->leftJoin("s.voteCounters", 'v')
+                                ->orderBy("sum_votes", 'DESC')
+                                ->where('s.isDeleted != true')
+                                ->andWhere('s.wip != true')
+                                ->andWhere('v.updatedAt >= :date')
+                                ->setParameter('date', (new \DateTime())->modify('-' . $days . " days"))
+                                ->groupBy('s.id')
+                                ->setMaxResults($results)
+                                ->setFirstResult(0)
+                                ->getQuery()->getResult();
 
         $data = [];
         foreach ($songs as $song) {
@@ -287,8 +273,7 @@ class ApiController extends AbstractController
             $em->persist($overlay);
             $em->flush();
         }
-        if (!isset ($data["Song"]))
-            return new Response("No Song", 500);
+        if (!isset($data["Song"])) return new Response("No Song", 500);
 
         $song = $songRepository->findOneBy(['newGuid' => $data["Song"]["Hash"]]);
         if ($song == null) {
@@ -299,7 +284,7 @@ class ApiController extends AbstractController
         }
         $rank = $difficultyRankRepository->findOneBy(['level' => $data["Song"]['Level']]);
         $songDiff = $songDifficultyRepository->findOneBy([
-            'song' => $song,
+            'song'           => $song,
             "difficultyRank" => $rank
         ]);
 
@@ -371,7 +356,7 @@ class ApiController extends AbstractController
                 ->distinct()
                 ->leftJoin('u.songsMapped', 's')
                 ->where('u.mapper_name LIKE :search')
-                ->setParameter('search', $request->get('q') . '%')
+                ->setParameter('search', $request->get('q').'%')
                 ->andWhere('s.isDeleted = false')
                 ->andWhere('s.wip = false')
                 ->andWhere('s.moderated = true')


### PR DESCRIPTION
This was a request from Xoanon to have an easier way of searching for songs with RagnaCustoms App.

Currently if you do a command like `!rc i like it`, two songs will be found - by Lacuna Coil and by Scooter.
But when you try to specify and enter `!rc i like it scooter`, no songs are found anymore.
This is a different behavior than in Song Library:
![image](https://github.com/Mouhaha-editions/RagnaCustoms/assets/12004018/35b0b389-f2cb-4c57-8db9-5ec9c4c4a700)

The downside of this change is that afterwards there might be more false-positives found, e.g. `!rc i like it` would also find the song "You Make It Feel Like Christmas", since it contains all of the phrases "i", "like" and "it".