### PR TITLE
Vote It box improvements

### DIFF
--- a/migrations/Version20241011210955.php
+++ b/migrations/Version20241011210955.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241011210955 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE vote_counter CHANGE votes_indc votes_indc TINYINT(1) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE vote_counter CHANGE votes_indc votes_indc TINYINT(1) NOT NULL');
+    }
+}

--- a/src/Entity/VoteCounter.php
+++ b/src/Entity/VoteCounter.php
@@ -25,7 +25,7 @@ class VoteCounter
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private $song;
 
-    #[ORM\Column(type: 'boolean', nullable: false)]
+    #[ORM\Column(type: 'boolean', nullable: true)]
     private $votes_indc;
 
     public function getId(): ?int
@@ -62,7 +62,7 @@ class VoteCounter
         return $this->votes_indc;
     }
 
-    public function setVotesIndc(bool $votesIndc): self
+    public function setVotesIndc(?bool $votesIndc): self
     {
         $this->votes_indc = $votesIndc;
 

--- a/templates/cms/homepage.html.twig
+++ b/templates/cms/homepage.html.twig
@@ -40,22 +40,9 @@
         </div>
       </div>
       {% if is_granted('ROLE_USER') %}
-      {% set songs = songService.getLastPlayedToVote(app.user) %}
-      {% if songs|length > 0 %}
-      <div class="row mt-2 vote-it">
-        <div class="col-12">
-          <h4 style="">{{ "You played them... now rate them!"|trans }}</h4>
-        </div>
-        {% import "songs/macros/song.html.twig" as macro_song %}
-
-        {% for song in songs %}
-          <div class="col-3">
-            {{ macro_song.voteItBox(song) }}
-          </div>
-        {% endfor %}
-    </div>
-    {% endif %}
-    {% endif %}
+        {% set songs = songService.getLastPlayedToVote(app.user) %}
+        {% include 'songs/partial/vote_it_box.html.twig' with {songs:songs} %}
+      {% endif %}
     </div>
   </header>
 

--- a/templates/songs/macros/song.html.twig
+++ b/templates/songs/macros/song.html.twig
@@ -32,7 +32,10 @@
       <div class="mapper pb-2 one-line">
         {% include 'songs/partial/mappers.html.twig' with {song:song} %}
       </div>
-      {% include 'songs/partial/downupvote.html.twig' with {song:song} %}
+      <div class="row px-3 justify-content-between">
+        {% include 'songs/partial/downupvote.html.twig' with {song:song} %}
+        {% include 'songs/partial/dismissvote.html.twig' with {song:song} %}
+      </div>
 
       <button class="btn btn-block btn-warning ajax-load ajax-modal-form btn-sm mt-3 mb-2 song-review"
               data-toggle="modal"

--- a/templates/songs/partial/dismissvote.html.twig
+++ b/templates/songs/partial/dismissvote.html.twig
@@ -1,0 +1,22 @@
+<div class="dismiss_vote" id="dismiss_vote_{{ song.id }}">
+    {% set voteCounter = song.isVoteCounterBy(app.user) %}
+    {% set upvotePosible = voteService.canUpDownVote(song, app.user) %}
+    {% if not is_granted('ROLE_USER') or not song.isAvailable or not upvotePosible or voteCounter is not null %}
+
+        <i style="color:grey;opacity:0.5" class="fas fa-trash" {% if not upvotePosible %}data-toggle="tooltip" title="Play the song first"{% endif %}></i>
+
+    {% else %}
+    <div><a style="text-decoration:none"
+           data-toggle="tooltip"
+           title="{{ "Dismiss"|trans }}"
+           class="ajax-link"
+           data-success-action="replace"
+           data-replace-selector="#vote-it"
+           href="#"
+           data-url="{{ path('song_vote_dismiss',{id:song.id}) }}"
+        >
+            <i class="fas fa-trash"></i>
+        </a>
+    </div>
+    {% endif %}
+</div>

--- a/templates/songs/partial/downupvote.html.twig
+++ b/templates/songs/partial/downupvote.html.twig
@@ -35,7 +35,7 @@
            data-success-action="replace"
            data-replace-selector="#up_down_vote_{{ song.id }}"
                 {% set isNegative = false %}
-                {% if voteCounter is not null and voteCounter.votesIndc == false %}
+                {% if voteCounter is not null and voteCounter.votesIndc is not null and voteCounter.votesIndc == false %}
                     {% set isNegative = true %}
                     title="{{ "Remove my downvote for this song"|trans }}"
                 {% else %}

--- a/templates/songs/partial/vote_it_box.html.twig
+++ b/templates/songs/partial/vote_it_box.html.twig
@@ -1,0 +1,14 @@
+{% if songs|length > 0 %}
+<div class="row mt-2 vote-it" id="vote-it">
+    <div class="col-12">
+        <h4 style="">{{ "You played them... now rate them!"|trans }}</h4>
+    </div>
+    {% import "songs/macros/song.html.twig" as macro_song %}
+
+    {% for song in songs %}
+        <div class="col-lg-3 col-md-6 col-sm-12 pb-md-0 pb-sm-3 pb-3">
+        {{ macro_song.voteItBox(song) }}
+        </div>
+    {% endfor %}
+</div>
+{% endif %}


### PR DESCRIPTION
1. Styling on mobile fixed:
    - Desktop
    ![image](https://github.com/user-attachments/assets/df173817-6f72-446d-9308-31cf1af4ec2d)
    - Tablet
    ![image](https://github.com/user-attachments/assets/563be0ee-ae35-43b5-92ba-f853090b016a)
    - Mobile
    ![image](https://github.com/user-attachments/assets/11446ce8-f43c-4f2f-8e8f-cafa643d839b)

2. Added possibility to dismiss songs that you don't want to review to allow users to see next options in line:
![image](https://github.com/user-attachments/assets/f877e076-d490-4920-95d4-28485ea9bf52)


The main idea here is that clicking the dismiss icon will add a `vote_counter` row with `votes_indc` set to `null`, so the `songService->getLastPlayedToVote` no longer picks it up. Upvote/downvote logic needed to be updated as well for this, so that the song doesn't appear again in Vote It box after users voted on it and then removed their votes later.

Deployment:
- [ ] Run migration `Version20241011210955.php` to allow for nullable `vote_counter.votes_indc`